### PR TITLE
Integer overflow now causes panics without std::num::wrapping::Wrapping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(core)]
+
 extern crate libc;
+
+use std::num::wrapping::Wrapping as w;
 
 #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios")))]
 mod imp {
@@ -55,7 +59,7 @@ pub fn precise_time_ns() -> u64 {
             libc::QueryPerformanceCounter(&mut ticks)
         }, 1);
 
-        return (ticks as u64 * 1000000000) / (ticks_per_s as u64);
+        return (w(ticks as u64) * w(1000000000)).0 / (ticks_per_s as u64);
     }
 
     #[cfg(any(target_os = "macos", target_os = "ios"))]


### PR DESCRIPTION
Getting 'arithmetic operation overflowed' panics with `rustc 1.0.0-nightly (fed12499e 2015-03-03) (built 2015-03-04)`
