### PR TITLE
Add precise_time_ms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,14 @@ pub fn precise_time_s() -> f64 {
     return (precise_time_ns() as f64) / 1000000000.;
 }
 
+/**
+ * Returns the current value of a high-resolution performance counter
+ * in milliseconds since an unspecified epoch.
+ */
+pub fn precise_time_ms() -> u64 {
+    return precise_time_ns() / 1000;
+}
+
 // Computes (value*numer)/denom without overflow, as long as both
 // (numer*denom) and the overall result fit into i64 (which is the case
 // for our time conversions).


### PR DESCRIPTION
There doesn't seem to be a function like this in the standard library, so I had this code laying for conversion and figured that it might be handy for other people using this library, even though converting to ms probably kills any actual precision.
